### PR TITLE
Fix/timerange picker analytics

### DIFF
--- a/src/components/TimeRangePicker/Overlay.tsx
+++ b/src/components/TimeRangePicker/Overlay.tsx
@@ -39,6 +39,12 @@ export const Overlay = ({
         to: "now",
         from: `now-${optionValue}${labelsToUnit[option.unit]}`,
       });
+    } else if (option.type === "absoluteInput") {
+      onChange({
+        label: `${option.label}: ${optionValue}`,
+        to: (optionValue || new Date().getFullYear()).toString(),
+        from: ((optionValue || new Date().getFullYear()) - 1).toString(),
+      });
     } else if (stats.isHistorical || option.type === "absolute") {
       const fromStr = option.from.toLocaleDateString();
       const toStr = option.to.toLocaleDateString();

--- a/src/components/TimeRangePicker/Overlay.tsx
+++ b/src/components/TimeRangePicker/Overlay.tsx
@@ -39,11 +39,21 @@ export const Overlay = ({
         to: "now",
         from: `now-${optionValue}${labelsToUnit[option.unit]}`,
       });
-    } else if (option.type === "absoluteInput") {
+    } else if (option.type === "select") {
+      const isYear = option.unit.includes("year");
+      const currentYear = new Date().getFullYear();
+      const currentValue = isYear ? currentYear : new Date().getMonth() + 1;
+      const newValue = optionValue || currentValue;
       onChange({
-        label: `${option.label}: ${optionValue}`,
-        to: (optionValue || new Date().getFullYear()).toString(),
-        from: ((optionValue || new Date().getFullYear()) - 1).toString(),
+        label: `${option.label}: ${isYear 
+          ? newValue 
+          : new Date(0, newValue, 0).toLocaleString("default", { month: "short" })}`,
+        to: isYear
+          ? new Date((newValue), 11, 31)
+          : new Date(currentYear, newValue, 0),
+        from: isYear
+          ? new Date(newValue, 0, 1)
+          : new Date(currentYear, newValue - 1, 0),
       });
     } else if (stats.isHistorical || option.type === "absolute") {
       const fromStr = option.from.toLocaleDateString();

--- a/src/components/TimeRangePicker/TimeOption.tsx
+++ b/src/components/TimeRangePicker/TimeOption.tsx
@@ -44,7 +44,7 @@ export const TimeOption = ({ active, onSelect, ...props }) => {
           <span className="tnic-hovertext">Click to select</span>
         </>
       )}
-      {type === "absoluteInput" && (
+      {type === "AbsoluteYearInput" && (
         <>
           <span>
             {label}:

--- a/src/components/TimeRangePicker/TimeOption.tsx
+++ b/src/components/TimeRangePicker/TimeOption.tsx
@@ -4,6 +4,7 @@ export const TimeOption = ({ active, onSelect, ...props }) => {
   const [value, setValue] = React.useState(props.default);
   const inputRef = React.useRef<HTMLInputElement>(null);
   const { type, label, unit } = props;
+  const isMonth = unit?.includes("month");
 
   React.useEffect(() => {
     if (props.default !== value) {
@@ -44,7 +45,7 @@ export const TimeOption = ({ active, onSelect, ...props }) => {
           <span className="tnic-hovertext">Click to select</span>
         </>
       )}
-      {type === "AbsoluteYearInput" && (
+      {type === "select" && (
         <>
           <span>
             {label}:
@@ -53,10 +54,14 @@ export const TimeOption = ({ active, onSelect, ...props }) => {
               ref={inputRef}
               type="number"
               value={value}
+              max={isMonth ? 12 : undefined}
+              min="1"
               onFocus={(e) => e.target.select()}
               onChange={(e) => setValue(e.target.value)}
             />
           </span>
+          {isMonth && <span>{new Date(0, value, 0)
+            .toLocaleString("default", { month: "short" })}</span>}
           <span className="tnic-hovertext">Click to select</span>
         </>
       )}

--- a/src/components/TimeRangePicker/TimeOption.tsx
+++ b/src/components/TimeRangePicker/TimeOption.tsx
@@ -59,9 +59,15 @@ export const TimeOption = ({ active, onSelect, ...props }) => {
               onFocus={(e) => e.target.select()}
               onChange={(e) => setValue(e.target.value)}
             />
+            {isMonth && (
+              <>
+                {new Date(0, value, 0).toLocaleString("default", {
+                  month: "short",
+                })}
+              </>
+            )}
           </span>
-          {isMonth && <span>{new Date(0, value, 0)
-            .toLocaleString("default", { month: "short" })}</span>}
+
           <span className="tnic-hovertext">Click to select</span>
         </>
       )}

--- a/src/components/TimeRangePicker/TimeOption.tsx
+++ b/src/components/TimeRangePicker/TimeOption.tsx
@@ -44,6 +44,22 @@ export const TimeOption = ({ active, onSelect, ...props }) => {
           <span className="tnic-hovertext">Click to select</span>
         </>
       )}
+      {type === "absoluteInput" && (
+        <>
+          <span>
+            {label}:
+            <input
+              className="tnic-input tnic-input-large"
+              ref={inputRef}
+              type="number"
+              value={value}
+              onFocus={(e) => e.target.select()}
+              onChange={(e) => setValue(e.target.value)}
+            />
+          </span>
+          <span className="tnic-hovertext">Click to select</span>
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/TimeRangePicker/index.stories.tsx
+++ b/src/components/TimeRangePicker/index.stories.tsx
@@ -24,7 +24,13 @@ export default {
   argTypes: {},
 };
 
-const Template = ({ alignRight, ...args }) => {
+const Template = ({
+  alignRight,
+  timeOptions,
+}: {
+  alignRight?: string;
+  timeOptions: any;
+}) => {
   const [timeRange, setTimeRange] = React.useState<{
     from: string | Date;
     to: string | Date;
@@ -32,7 +38,6 @@ const Template = ({ alignRight, ...args }) => {
     from: "now-1h/d",
     to: "now",
   });
-
   return (
     <>
       <div style={alignRight ? { float: "right" } : {}}>
@@ -43,6 +48,7 @@ const Template = ({ alignRight, ...args }) => {
           timeRange={timeRange}
           onChange={(timeRange) => setTimeRange(timeRange)}
           {...(alignRight ? { align: "right" } : {})}
+          timeOptions={timeOptions}
         />
       </div>
       <br />
@@ -167,3 +173,74 @@ const AllowedRangeTemplate = (args) => (
 );
 
 export const AllowedRange = AllowedRangeTemplate.bind({});
+
+export const AllTimeOptions = (args) => (
+  <Template
+    timeOptions={[
+      {
+        type: "fixed",
+        label: "Today",
+        to: "now",
+        from: "now-1h/d",
+      },
+      {
+        type: "fixed",
+        label: "Yesterday",
+        to: "now-1h/d",
+        from: "now-1d/d",
+      },
+      {
+        type: "fixed",
+        label: "This Week",
+        to: "now",
+        from: "now/w",
+      },
+
+      {
+        type: "fixed",
+        label: "This Month",
+        to: "now",
+        from: "now/M",
+      },
+
+      {
+        type: "fixed",
+        label: "This Year",
+        to: "now",
+        from: "now/y",
+      },
+
+      {
+        type: "input",
+        unit: "hours",
+        default: 24,
+      },
+      {
+        type: "input",
+        unit: "days",
+        default: 7,
+      },
+
+      {
+        type: "input",
+        unit: "months",
+        default: 3,
+      },
+
+      {
+        type: "select",
+        unit: "years",
+        label: "Year",
+        default: new Date().getFullYear() - 1,
+      },
+
+      {
+        type: "select",
+        unit: "months",
+        label: "Month",
+        default: new Date().getMonth(),
+      },
+    ]}
+    {...args}
+  />
+);

--- a/src/components/TimeRangePicker/index.tsx
+++ b/src/components/TimeRangePicker/index.tsx
@@ -22,24 +22,29 @@ const defaultProps = {
       to: "now-1h/d",
       from: "now-1d/d",
     },
+    /*
     {
       type: "fixed",
       label: "This Week",
       to: "now",
       from: "now/w",
     },
+    */
     {
       type: "fixed",
       label: "This Month",
       to: "now",
       from: "now/M",
     },
+    /*
     {
       type: "fixed",
       label: "This Year",
       to: "now",
       from: "now/y",
     },
+    */
+
     {
       type: "input",
       unit: "hours",
@@ -50,17 +55,20 @@ const defaultProps = {
       unit: "days",
       default: 7,
     },
+    /*
     {
       type: "input",
       unit: "months",
       default: 3,
     },
+  
     {
       type: "select",
       unit: "years",
       label: "Year",
       default: new Date().getFullYear() - 1,
     },
+      */
     {
       type: "select",
       unit: "months",
@@ -75,7 +83,7 @@ type SelectTimeOption = {
   unit: "years" | "months";
   label: string;
   default: number;
-}
+};
 
 type InputTimeOption = {
   type: "input";
@@ -148,6 +156,8 @@ export const TimeRangePicker = ({
   if (!timeRange || !timeRange.to) {
     return <div></div>;
   }
+
+  console.log(timeOptions);
 
   return (
     <div className={classes.join(" ")}>

--- a/src/components/TimeRangePicker/index.tsx
+++ b/src/components/TimeRangePicker/index.tsx
@@ -56,17 +56,23 @@ const defaultProps = {
       default: 3,
     },
     {
-      type: "AbsoluteYearInput",
+      type: "select",
       unit: "years",
       label: "Year",
       default: new Date().getFullYear() - 1,
     },
+    {
+      type: "select",
+      unit: "months",
+      label: "Month",
+      default: new Date().getMonth(),
+    },
   ],
 };
 
-type AbsoluteYearTimeOption = {
-  type: "AbsoluteYearInput";
-  unit: "years";
+type SelectTimeOption = {
+  type: "select";
+  unit: "years" | "months";
   label: string;
   default: number;
 }
@@ -83,9 +89,7 @@ type FixedTimeOption = {
   from: string | Date;
 };
 
-type AbsoluteInputTimeOption = AbsoluteYearTimeOption;
-
-type TimeOption = InputTimeOption | FixedTimeOption | AbsoluteInputTimeOption;
+type TimeOption = InputTimeOption | FixedTimeOption | SelectTimeOption;
 
 interface TimeRangePickerProps {
   renderButton: (label: string, onClick: () => void) => JSX.Element;
@@ -106,6 +110,8 @@ function getTimeRangeForLabel(
   timeRange: ITimeRange,
   timeOptions: TimeOption[]
 ) {
+  console.log(timeRange);
+
   if (timeRange?.label) {
     return timeRange.label;
   }

--- a/src/components/TimeRangePicker/index.tsx
+++ b/src/components/TimeRangePicker/index.tsx
@@ -56,13 +56,20 @@ const defaultProps = {
       default: 3,
     },
     {
-      type: "absoluteInput",
+      type: "AbsoluteYearInput",
       unit: "years",
       label: "Year",
       default: new Date().getFullYear() - 1,
     },
   ],
 };
+
+type AbsoluteYearTimeOption = {
+  type: "AbsoluteYearInput";
+  unit: "years";
+  label: string;
+  default: number;
+}
 
 type InputTimeOption = {
   type: "input";
@@ -75,12 +82,8 @@ type FixedTimeOption = {
   to: string | Date;
   from: string | Date;
 };
-type AbsoluteInputTimeOption = {
-  type: "absoluteInput";
-  unit: "minutes" | "hours" | "days" | "weeks" | "months" | "years";
-  label: string;
-  default: number;
-};
+
+type AbsoluteInputTimeOption = AbsoluteYearTimeOption;
 
 type TimeOption = InputTimeOption | FixedTimeOption | AbsoluteInputTimeOption;
 

--- a/src/components/TimeRangePicker/index.tsx
+++ b/src/components/TimeRangePicker/index.tsx
@@ -55,6 +55,12 @@ const defaultProps = {
       unit: "months",
       default: 3,
     },
+    {
+      type: "absoluteInput",
+      unit: "years",
+      label: "Year",
+      default: new Date().getFullYear() - 1,
+    },
   ],
 };
 
@@ -69,8 +75,14 @@ type FixedTimeOption = {
   to: string | Date;
   from: string | Date;
 };
+type AbsoluteInputTimeOption = {
+  type: "absoluteInput";
+  unit: "minutes" | "hours" | "days" | "weeks" | "months" | "years";
+  label: string;
+  default: number;
+};
 
-type TimeOption = InputTimeOption | FixedTimeOption;
+type TimeOption = InputTimeOption | FixedTimeOption | AbsoluteInputTimeOption;
 
 interface TimeRangePickerProps {
   renderButton: (label: string, onClick: () => void) => JSX.Element;

--- a/src/components/TimeRangePicker/index.tsx
+++ b/src/components/TimeRangePicker/index.tsx
@@ -110,8 +110,6 @@ function getTimeRangeForLabel(
   timeRange: ITimeRange,
   timeOptions: TimeOption[]
 ) {
-  console.log(timeRange);
-
   if (timeRange?.label) {
     return timeRange.label;
   }

--- a/src/components/TimeRangePicker/index.tsx
+++ b/src/components/TimeRangePicker/index.tsx
@@ -157,8 +157,6 @@ export const TimeRangePicker = ({
     return <div></div>;
   }
 
-  console.log(timeOptions);
-
   return (
     <div className={classes.join(" ")}>
       {renderButton(

--- a/src/styles.css
+++ b/src/styles.css
@@ -317,6 +317,10 @@
   width: 34px;
 }
 
+.tnic-timeOption .tnic-input-large {
+  width: 64px;
+}
+
 /*** Title ***/
 .tnic-title {
   font-weight: bold;


### PR DESCRIPTION
Add ability to select a full year

- Added absolute input with input years & input type
- Added case for absoluteInput type option
- Added case for absoluteInput to create UI components
- Added .tnic-input-large class for larger input fields

Fixes: https://linear.app/e-flux/issue/E-262#comment-0c5ee525